### PR TITLE
[FIX][3864903][M1809118532733] ecodrip_account: Fixed column not appearing

### DIFF
--- a/ecodrip_account/models/account_payment.py
+++ b/ecodrip_account/models/account_payment.py
@@ -36,7 +36,7 @@ class AccountPayment(models.Model):
             else:
                 amount_residual_str = formatLang(self.env, invoice_sign * invoice.amount_residual, currency_obj=invoice.currency_id)
 
-            if invoice.payment_state == 'in_payment' and invoice.move_type == 'in_invoice':
+            if (invoice.payment_state == 'in_payment' or invoice.payment_state == 'paid') and invoice.move_type == 'in_invoice':
                 last_payment_date = max([date for date in self.env['account.payment'].search([('reconciled_bill_ids', 'in', invoice.ids)]).mapped('date') if date], default=None)
                 if last_payment_date and invoice.early_payment_deadline and self.date == last_payment_date and self.date <= invoice.early_payment_deadline:
                     discount = invoice.early_payment_discount


### PR DESCRIPTION
### Description

*Fixed issue with the check not having the discount taken column being printed.*
There was a change with the account journals being used by the client and due to the initial condition that was put in, the customization would only trigger when the payment status was in_payment. This resulted in the check not displaying the Discount Taken column. The BSA on the ticket mentioned that adding the paid status would be fine to display the discount taken column.

Link to task: [#ID](https://www.odoo.com/odoo/timesheets/project.task/3864903?cids=3)
